### PR TITLE
Wrap client id generation in its own function

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/matei-oltean/go-torrent/fileutils"
 	"github.com/matei-oltean/go-torrent/peer"
+	"github.com/matei-oltean/go-torrent/utils"
 )
 
 func main() {
 	torrentFilePath := "fileutils/testData/debian-10.2.0-amd64-netinst.iso.torrent"
 	torrentFile, _ := fileutils.OpenTorrent(torrentFilePath)
-	id := [20]byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
+	id := utils.ClientID()
 	var port uint16 = 6882
 	trackerURL, _ := torrentFile.GetAnnounceURL(id, port)
 	println(trackerURL)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,10 @@
+package utils
+
+import "crypto/rand"
+
+// ClientID returns the id -GT0000- followed by 12 random bytes
+func ClientID() [20]byte {
+	id := [20]byte{'-', 'G', 'T', '0', '0', '0', '0', '-'}
+	rand.Read(id[8:])
+	return id
+}


### PR DESCRIPTION
Using *GT* for *go-torrent* as client name and 0000 as version. Once version 1 (i.e. a working version) comes out, the generator function will be tweaked to take the version into account.