### PR TITLE
Add multifile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To use:
 * Clone the repository with `https://github.com/matei-oltean/go-torrent.git` (or `go get github.com/matei-oltean/go-torrent`)
 * Go to the cloned repository (`cd go-torrent`)
 * Build it `go build`
-* Launch it with `./go-torrent -f path_to_torrent_file`. You can also force the name of the output file by adding `-o path_to_output`; if not supplied, the file will be downloaded in the same folder as the torrent file with the name supplied by the torrent file. Please note that the client only works with single file torrents.
+* Launch it with `./go-torrent -f path_to_torrent_file`. You can also force the name of the output file by adding `-o path_to_output`; if not supplied, the file will be downloaded in the same folder as the torrent file with the name supplied by the torrent file.
 
 Next steps:
 * Clean up the code (package separation, add tests, etc.)

--- a/client/client.go
+++ b/client/client.go
@@ -13,18 +13,19 @@ import (
 
 // clientID returns '-', the id 'GT' followed by the version number, '-' and 12 random bytes
 func clientID() [20]byte {
-	id := [20]byte{'-', 'G', 'T', '0', '1', '0', '2', '-'}
+	id := [20]byte{'-', 'G', 'T', '0', '1', '0', '3', '-'}
 	rand.Read(id[8:])
 	return id
 }
 
 // downloadPieces retrieves the file as a byte array
 // from torrent file, a list of peers and a client ID
-func downloadPieces(torrentFile *fileutils.TorrentFile, peersAddr []string, clientID [20]byte) ([]byte, error) {
+// and writes them to the file system
+func downloadPieces(torrentFile *fileutils.TorrentFile, peersAddr []string, clientID [20]byte, outDir string) error {
 	fileLen := torrentFile.Length
 	pieceLen := torrentFile.PieceLength
 	numPieces := len(torrentFile.Pieces)
-	file := make([]byte, fileLen)
+	files := make([]byte, fileLen)
 	// Create chan of pieces to download
 	pieces := make(chan *peer.Piece, fileLen)
 	// Create chan of results to collect
@@ -53,12 +54,31 @@ func downloadPieces(torrentFile *fileutils.TorrentFile, peersAddr []string, clie
 	done := 0
 	for done < numPieces {
 		result := <-results
-		copy(file[result.Index*pieceLen:], result.Value)
+		copy(files[result.Index*pieceLen:], result.Value)
 		done++
 		log.Printf("Downloaded %d/%d pieces (%.2f%%)", done, numPieces, float64(done)/float64(numPieces)*100)
 	}
+	start := 0
+	for _, file := range torrentFile.Files {
+		outPath := outDir
+		for _, dir := range file.Path {
+			outPath = filepath.Join(outPath, dir)
+		}
+		os.MkdirAll(filepath.Dir(outPath), os.ModePerm)
+		outFile, err := os.Create(outPath)
+		if err != nil {
+			return err
+		}
+		defer outFile.Close()
+		_, err = outFile.Write(files[start : start+file.Length])
+		start += file.Length
+		if err != nil {
+			return err
+		}
+		log.Printf("Successfully saved file at %s", outPath)
 
-	return file, nil
+	}
+	return nil
 }
 
 // Download retrieves the file and saves it to the specified path
@@ -70,28 +90,23 @@ func Download(torrentPath, outputPath string) error {
 	if err != nil {
 		return err
 	}
-	outPath := outputPath
-	if outPath == "" {
-		outPath = filepath.Join(filepath.Dir(torrentPath), t.Name)
+	outDir := outputPath
+	if outDir == "" {
+		outDir = filepath.Dir(torrentPath)
 	}
-	outFile, err := os.Create(outPath)
-	if err != nil {
-		return err
+	// If there are multiple files, create a containing folder
+	if t.Multi() {
+		outDir = filepath.Join(outDir, t.Name)
+		os.MkdirAll(outDir, os.ModePerm)
 	}
-	defer outFile.Close()
 	peers, err := t.GetPeers(id)
 	if err != nil {
 		return err
 	}
 	log.Printf("Received %d peers from tracker", len(peers))
-	file, err := downloadPieces(t, peers, id)
+	err = downloadPieces(t, peers, id, outDir)
 	if err != nil {
 		return err
 	}
-	_, err = outFile.Write(file)
-	if err != nil {
-		return err
-	}
-	log.Printf("Successfully saved file at %s", outPath)
 	return nil
 }

--- a/fileutils/torrentfile.go
+++ b/fileutils/torrentfile.go
@@ -421,3 +421,8 @@ func (t *TorrentFile) getPeersUDP(clientID [20]byte) ([]string, error) {
 	}
 	return nil, errors.New("timed out after 8 retries")
 }
+
+// Multi returns true if there are multiple files
+func (t *TorrentFile) Multi() bool {
+	return len(t.Files) > 1
+}


### PR DESCRIPTION
Multifile downloading now works.
This first implementation is however very bad for large torrents: an array of the size of the data is allocated at the start, everything is kept in memory and at the end, everything is flushed at once.