### PR TITLE
Use only short flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To use:
 * Clone the repository with `https://github.com/matei-oltean/go-torrent.git` (or `go get github.com/matei-oltean/go-torrent`)
 * Go to the cloned repository (`cd go-torrent`)
 * Build it `go build`
-* Launch it with `./go-torrent -f path_to_torrent_file`. You can also force the name of the output file by adding `-o path_to_output`; if not supplied, the file will be downloaded in the same folder as the torrent file with the name supplied by the torrent file.
+* Launch it with `./go-torrent path_to_torrent_file`. You can also force the name of the output file by adding `-o path_to_output`; if not supplied, the file will be downloaded in the same folder as the torrent file with the name supplied by the torrent file.
 
 Next steps:
 * Clean up the code (package separation, add tests, etc.)

--- a/main.go
+++ b/main.go
@@ -11,10 +11,7 @@ func main() {
 	var outPath string
 
 	flag.StringVar(&torrentPath, "f", "", torrentDescription)
-	flag.StringVar(&torrentPath, "file", "", torrentDescription)
-
 	flag.StringVar(&outPath, "o", "", outDescription)
-	flag.StringVar(&outPath, "output", "", outDescription)
 
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -1,26 +1,35 @@
 package main
 
-import "flag"
+import (
+	"flag"
+	"fmt"
+	"os"
+)
 
 func main() {
 	const (
-		torrentDescription = "Required: path of the torrent file."
-		outDescription     = "Optional: path of the output file.\nIf not set, the file will be downloaded in the same folder as the torrent file with the name in that file."
+		outDescription = "Optional: path of the output file.\nIf not set, the file will be downloaded in the same folder as the torrent file with the name in that file."
 	)
-	var torrentPath string
-	var outPath string
 
-	flag.StringVar(&torrentPath, "f", "", torrentDescription)
-	flag.StringVar(&outPath, "o", "", outDescription)
+	args := os.Args
 
-	flag.Parse()
-
-	if torrentPath == "" {
+	if len(args) <= 1 {
 		println("Please provide a path for the torrent file")
 		return
 	}
 
-	err := Download(torrentPath, outPath)
+	torrentPath := args[1]
+	_, err := os.Stat(torrentPath)
+	if err != nil {
+		fmt.Printf("The path %s you provided is invalid: %s\n", torrentPath, err)
+		return
+	}
+
+	var outPath string
+	flag.StringVar(&outPath, "o", "", outDescription)
+	flag.Parse()
+
+	err = Download(torrentPath, outPath)
 	if err != nil {
 		println(err.Error())
 		return


### PR DESCRIPTION
Use only short flags for arguments. Because of how Go`s `flag` library works they have to be declared twice in the code and appear twice when running `./go-torrent --help`. Keeping only the short version seems tidier.